### PR TITLE
Add configuration for maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,15 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
I've experienced multiple errors that maven told me “use -source 5 or higher to enable …” when building tarql. I could solve this with a solution from stackoverflow [1], which is contained in this pull request.

[1] http://stackoverflow.com/questions/2451268/maven-use-source-5-or-higher-to-enable-static-import-declarations
