### PR TITLE
support for jsonld

### DIFF
--- a/src/main/java/org/deri/tarql/tarql.java
+++ b/src/main/java/org/deri/tarql/tarql.java
@@ -63,6 +63,8 @@ public class tarql extends CmdGeneral {
 	private final ArgDecl withoutHeaderArg = new ArgDecl(false, "no-header-row", "no-header", "H");
 	private final ArgDecl encodingArg = new ArgDecl(true, "encoding", "e");
 	private final ArgDecl nTriplesArg = new ArgDecl(false, "ntriples");
+	private final ArgDecl jsonLDArg = new ArgDecl(false, "jsonld");
+
 	private final ArgDecl delimiterArg = new ArgDecl(true, "delimiter", "d");
 	private final ArgDecl tabsArg = new ArgDecl(false, "tabs", "tab", "t");
 	private final ArgDecl quoteArg = new ArgDecl(true, "quotechar");
@@ -77,6 +79,8 @@ public class tarql extends CmdGeneral {
 	private CSVOptions options = new CSVOptions();
 	private boolean testQuery = false;
 	private boolean writeNTriples = false;
+	private boolean writeJSONLD = false;
+
 	private String baseIRI = null;
 	private boolean writeBase = false;
 	private int dedupWindowSize = 0;
@@ -90,6 +94,7 @@ public class tarql extends CmdGeneral {
 		add(testQueryArg,     "--test", "Show CONSTRUCT template and first rows only (for query debugging)");
 		add(writeBaseArg,     "--write-base", "Write @base if output is Turtle");
 		add(nTriplesArg,      "--ntriples", "Write N-Triples instead of Turtle");
+		add(jsonLDArg,        "--josnld", "Write JSON-LD instead of Turtle");
 		add(dedupArg, "--dedup", "Window size in which to remove duplicate triples");
 
 		getUsage().startCategory("Input options");
@@ -145,6 +150,9 @@ public class tarql extends CmdGeneral {
 		}
 		if (hasArg(nTriplesArg)) {
 			writeNTriples = true;
+		}
+		if (hasArg(jsonLDArg)) {
+			writeJSONLD = true;
 		}
 		if (hasArg(tabsArg)) {
 			options.setDefaultsForTSV();
@@ -213,7 +221,11 @@ public class tarql extends CmdGeneral {
 				writer.setDedupWindowSize(dedupWindowSize);
 				if (writeNTriples) {
 					writer.writeNTriples();
-				} else {
+				}
+				else if(writeJSONLD){
+					writer.writeJSONLD();
+				} 
+				else {
 					writer.writeTurtle(
 							q.getPrologue().getBaseURI(),
 							q.getPrologue().getPrefixMapping(), writeBase);


### PR DESCRIPTION
@cygri 
I am attaching output for the JSON-LD output for the example csv from the documentation.

`{
  "@graph" : [ {
    "@id" : "http://ex.org/companies/chosenlist-com",
    "@type" : "http://ex.org/a#Organization",
    "category" : "\"web\"",
    "city" : "\"Scottsdale\"",
    "employees" : "\"5\"^^http://www.w3.org/2001/XMLSchema#integer",
    "fundationDate" : [ "\"1-Oct-06\"", "\"25-Jan-08\"" ],
    "name" : "\"ChosenList.com\"",
    "permalink" : "\"chosenlist-com\"",
    "raisedAmt" : [ "\"233750\"^^http://www.w3.org/2001/XMLSchema#decimal", "\"140000\"^^http://www.w3.org/2001/XMLSchema#decimal" ],
    "raisedCurrency" : "\"USD\"",
    "round" : [ "\"angel\"", "\"seed\"" ],
    "state" : "\"AZ\""
  }, {
    "@id" : "http://ex.org/companies/digg",
    "@type" : "http://ex.org/a#Organization",
    "category" : "\"web\"",
    "city" : "\"San Francisco\"",
    "employees" : "\"60\"^^http://www.w3.org/2001/XMLSchema#integer",
    "fundationDate" : [ "\"1-Dec-06\"", "\"1-Oct-05\"" ],
    "name" : "\"Digg\"",
    "permalink" : "\"digg\"",
    "raisedAmt" : [ "\"8500000\"^^http://www.w3.org/2001/XMLSchema#decimal", "\"2800000\"^^http://www.w3.org/2001/XMLSchema#decimal" ],
    "raisedCurrency" : "\"USD\"",
    "round" : [ "\"a\"", "\"b\"" ],
    "state" : "\"CA\""
  }, {
    "@id" : "http://ex.org/companies/facebook",
    "@type" : "http://ex.org/a#Organization",
    "category" : "\"web\"",
    "city" : "\"Palo Alto\"",
    "employees" : "\"450\"^^http://www.w3.org/2001/XMLSchema#integer",
    "fundationDate" : [ "\"1-Mar-08\"", "\"1-May-08\"", "\"1-Sep-04\"", "\"15-Jan-08\"", "\"1-Apr-06\"", "\"1-Oct-07\"", "\"1-May-05\"" ],
    "name" : "\"Facebook\"",
    "permalink" : "\"facebook\"",
    "raisedAmt" : [ "\"27500000\"^^http://www.w3.org/2001/XMLSchema#decimal", "\"15000000\"^^http://www.w3.org/2001/XMLSchema#decimal", "\"40000000\"^^http://www.w3.org/2001/XMLSchema#decimal", "\"12700000\"^^http://www.w3.org/2001/XMLSchema#decimal", "\"100000000\"^^http://www.w3.org/2001/XMLSchema#decimal", "\"500000\"^^http://www.w3.org/2001/XMLSchema#decimal", "\"300000000\"^^http://www.w3.org/2001/XMLSchema#decimal" ],
    "raisedCurrency" : "\"USD\"",
    "round" : [ "\"angel\"", "\"c\"", "\"b\"", "\"debt_round\"", "\"a\"" ],
    "state" : "\"CA\""
  }, {
    "@id" : "http://ex.org/companies/flypaper",
    "@type" : "http://ex.org/a#Organization",
    "category" : "\"web\"",
    "city" : "\"Phoenix\"",
    "fundationDate" : "\"1-Feb-08\"",
    "name" : "\"Flypaper\"",
    "permalink" : "\"flypaper\"",
    "raisedAmt" : "\"3000000\"^^http://www.w3.org/2001/XMLSchema#decimal",
    "raisedCurrency" : "\"USD\"",
    "round" : "\"a\"",
    "state" : "\"AZ\""
  }, {
    "@id" : "http://ex.org/companies/gauto",
    "@type" : "http://ex.org/a#Organization",
    "category" : "\"web\"",
    "city" : "\"Scottsdale\"",
    "employees" : "\"4\"^^http://www.w3.org/2001/XMLSchema#integer",
    "fundationDate" : "\"1-Jan-08\"",
    "name" : "\"gAuto\"",
    "permalink" : "\"gauto\"",
    "raisedAmt" : "\"250000\"^^http://www.w3.org/2001/XMLSchema#decimal",
    "raisedCurrency" : "\"USD\"",
    "round" : "\"seed\"",
    "state" : "\"AZ\""
  }, {
    "@id" : "http://ex.org/companies/infusionsoft",
    "@type" : "http://ex.org/a#Organization",
    "category" : "\"software\"",
    "city" : "\"Gilbert\"",
    "employees" : "\"105\"^^http://www.w3.org/2001/XMLSchema#integer",
    "fundationDate" : "\"1-Oct-07\"",
    "name" : "\"Infusionsoft\"",
    "permalink" : "\"infusionsoft\"",
    "raisedAmt" : "\"9000000\"^^http://www.w3.org/2001/XMLSchema#decimal",
    "raisedCurrency" : "\"USD\"",
    "round" : "\"a\"",
    "state" : "\"AZ\""
  }, {
    "@id" : "http://ex.org/companies/lifelock",
    "@type" : "http://ex.org/a#Organization",
    "category" : "\"web\"",
    "city" : "\"Tempe\"",
    "fundationDate" : [ "\"1-Jan-08\"", "\"1-May-07\"", "\"1-Oct-06\"" ],
    "name" : "\"LifeLock\"",
    "permalink" : "\"lifelock\"",
    "raisedAmt" : [ "\"25000000\"^^http://www.w3.org/2001/XMLSchema#decimal", "\"6850000\"^^http://www.w3.org/2001/XMLSchema#decimal", "\"6000000\"^^http://www.w3.org/2001/XMLSchema#decimal" ],
    "raisedCurrency" : "\"USD\"",
    "round" : [ "\"c\"", "\"<http://example.com/a>\"", "\"http://example.com/b\"" ],
    "state" : "\"AZ\""
  }, {
    "@id" : "http://ex.org/companies/mycityfaces",
    "@type" : "http://ex.org/a#Organization",
    "category" : "\"web\"",
    "city" : "\"Scottsdale\"",
    "employees" : "\"7\"^^http://www.w3.org/2001/XMLSchema#integer",
    "fundationDate" : "\"1-Jan-08\"",
    "name" : "\"MyCityFaces\"",
    "permalink" : "\"mycityfaces\"",
    "raisedAmt" : "\"50000\"^^http://www.w3.org/2001/XMLSchema#decimal",
    "raisedCurrency" : "\"USD\"",
    "round" : "\"seed\"",
    "state" : "\"AZ\""
  } ],
  "@context" : {
    "state" : {
      "@id" : "http://ex.org/a#state",
      "@type" : "@id"
    },
    "permalink" : {
      "@id" : "http://ex.org/a#permalink",
      "@type" : "@id"
    },
    "employees" : {
      "@id" : "http://ex.org/a#employees",
      "@type" : "@id"
    },
    "city" : {
      "@id" : "http://ex.org/a#city",
      "@type" : "@id"
    },
    "raisedCurrency" : {
      "@id" : "http://ex.org/a#raisedCurrency",
      "@type" : "@id"
    },
    "raisedAmt" : {
      "@id" : "http://ex.org/a#raisedAmt",
      "@type" : "@id"
    },
    "round" : {
      "@id" : "http://ex.org/a#round",
      "@type" : "@id"
    },
    "category" : {
      "@id" : "http://ex.org/a#category",
      "@type" : "@id"
    },
    "name" : {
      "@id" : "http://ex.org/a#name",
      "@type" : "@id"
    },
    "fundationDate" : {
      "@id" : "http://ex.org/a#fundationDate",
      "@type" : "@id"
    }
  }
}
`

You can test this by running 
`sh bin/tarql --jsonld ../../examples/query.sparql ../../examples/testTarql.csv`
