### PR TITLE
Use 755 for directories. Use 755 for scripts. Use 644 for jar files.

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -12,6 +12,8 @@
         <include>*.bat</include>
       </includes>
       <lineEnding>keep</lineEnding>
+      <fileMode>755</fileMode>
+      <directoryMode>755</directoryMode>
     </fileSet>
     <fileSet>
       <directory>target/appassembler/bin</directory>
@@ -19,8 +21,9 @@
       <excludes>
         <exclude>*.bat</exclude>
       </excludes>
-      <fileMode>744</fileMode>
+      <fileMode>755</fileMode>
       <lineEnding>keep</lineEnding>
+      <directoryMode>755</directoryMode>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}</directory>
@@ -30,11 +33,13 @@
         <include>LICENSE*</include>
         <include>NOTICE*</include>
       </includes>
+      <fileMode>644</fileMode>
     </fileSet>
   </fileSets>
   <dependencySets>
     <dependencySet>
       <outputDirectory>lib</outputDirectory>
+      <fileMode>644</fileMode>
     </dependencySet>
   </dependencySets>
 </assembly>


### PR DESCRIPTION
Hi,

Downloaded `tarql` today after reading about it from [Bob DuCharme's post](http://www.bobdc.com/blog/tarql/). Thanks for `tarql`, really useful.

After downloading the zip (was following his instructions) I noticed that the permission of the LICENSE, README, and directories was a bit awkward (README was executable).

This PR tries to address that by setting `<fileMode>` and `<directoryMode />` for directories, LICENSE, README, and jar files.

Before this PR:

![image](https://user-images.githubusercontent.com/304786/85915675-9d7fdc00-b89d-11ea-8fda-7de2ab8a8048.png)

After this PR:

![image](https://user-images.githubusercontent.com/304786/85915647-6f020100-b89d-11ea-8d10-2f527ec44a50.png)

Cheers
Bruno